### PR TITLE
allow DKIM timestamp to be few seconds in future

### DIFF
--- a/libsauth/dkim/dkimsignature.c
+++ b/libsauth/dkim/dkimsignature.c
@@ -818,7 +818,8 @@ DkimSignature_checkFutureTimestamp(const DkimSignature *self)
      * timestamp in the future.
      */
     if (0LL < self->signing_timestamp
-        && (long long) self->verification_time < self->signing_timestamp) {
+        && (long long) self->verification_time < self->signing_timestamp
+        && self->signing_timestamp - (long long) self->verification_time > 600) {
         DkimLogPermFail("this signature had signed in the future: timestamp=%lld, now=%ld",
                         self->signing_timestamp, self->verification_time);
         return DSTAT_PERMFAIL_INCONSISTENT_TIMESTAMP;

--- a/yenma/yenmamfi.c
+++ b/yenma/yenmamfi.c
@@ -577,7 +577,11 @@ static bool
 yenma_setup_session(YenmaSession *session, _SOCK_ADDR *hostaddr)
 {
     // [SPF] Storing the source IP address
-    free(session->hostaddr);
+    if (NULL == hostaddr) {
+        LogError("milter host address is NULL");
+        return false;
+    }   // end if
+    if (session->hostaddr) free(session->hostaddr);
     session->hostaddr = milter_dupaddr(hostaddr);
     if (NULL == session->hostaddr) {
         LogError("milter socket address duplication failed: errno=%s", strerror(errno));


### PR DESCRIPTION
Allow DKIM timestamp to be up to 600 seconds in future to prevent DKIM
failure in case of slightly unsynced clocks.
