### PR TITLE
Prevent NULL pointer dereference in yenma_setup_session()

### DIFF
--- a/yenma/yenmamfi.c
+++ b/yenma/yenmamfi.c
@@ -577,7 +577,11 @@ static bool
 yenma_setup_session(YenmaSession *session, _SOCK_ADDR *hostaddr)
 {
     // [SPF] Storing the source IP address
-    free(session->hostaddr);
+    if (NULL == hostaddr) {
+        LogError("milter host address is NULL");
+        return false;
+    }   // end if
+    if (session->hostaddr) free(session->hostaddr);
     session->hostaddr = milter_dupaddr(hostaddr);
     if (NULL == session->hostaddr) {
         LogError("milter socket address duplication failed: errno=%s", strerror(errno));


### PR DESCRIPTION
yenma segfaults periodically (Ubuntu + postfix):

root@mailsrv-2:/usr/local/libexec# grep yenma /var/log/kern.log
Feb 17 03:14:27 mailsrv-2 kernel: [583626.514566] yenma[6765]: segfault at 0 ip 00000000004066a2 sp 00007f359e5fdc60 error 4 in yenma[400000+1e000]
root@mailsrv-2:/usr/local/libexec# addr2line -e yenma 00000000004066a2
/root/yenma-master/yenma/yenmamfi.c:585
