### PR TITLE
libsauth: OpenSSL 1.1 support

### DIFF
--- a/libsauth/base/openssl-evp-compat.h
+++ b/libsauth/base/openssl-evp-compat.h
@@ -1,0 +1,24 @@
+#ifndef OPENSSL_EVP_COMPAT_H
+
+#include <openssl/evp.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+/* OpenSSL 1.0 introduces EVP_PKEY accessors */
+
+static inline int EVP_PKEY_id(const EVP_PKEY *pkey) {
+    return pkey->type;
+}
+
+static inline int EVP_PKEY_base_id(const EVP_PKEY *pkey) {
+    return EVP_PKEY_type(pkey->type);
+}
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+/* OpenSSL 1.1 renames EVP_MD_CTX_{create,destroy} to EVP_MD_CTX_{new,free} */
+
+#define EVP_MD_CTX_new() EVP_MD_CTX_create()
+#define EVP_MD_CTX_free(ctx) EVP_MD_CTX_destroy((ctx))
+#endif
+
+#endif /* OPENSSL_EVP_COMPAT_H */

--- a/libsauth/dkim/dkimpublickey.c
+++ b/libsauth/dkim/dkimpublickey.c
@@ -36,6 +36,7 @@
 #include "intarray.h"
 #include "inetdomain.h"
 #include "inetmailbox.h"
+#include "openssl-evp-compat.h"
 #include "dnsresolv.h"
 #include "dkim.h"
 #include "dkimspec.h"
@@ -395,20 +396,20 @@ DkimPublicKey_build(const DkimVerificationPolicy *policy, const char *keyval, co
     // compare key type key-k-tag declared and stored in key-p-tag
     switch (self->keytype) {
     case DKIM_KEY_TYPE_RSA:
-        if (EVP_PKEY_RSA != EVP_PKEY_type(self->pkey->type)) {
+        if (EVP_PKEY_RSA != EVP_PKEY_base_id(self->pkey)) {
             DkimLogPermFail
                 ("key-k-tag and key-p-tag doesn't match: domain=%s, keyalg=0x%x, keytype=0x%x",
-                 domain, self->keytype, EVP_PKEY_type(self->pkey->type));
+                 domain, self->keytype, EVP_PKEY_base_id(self->pkey));
             DkimPublicKey_free(self);
             return DSTAT_PERMFAIL_PUBLICKEY_TYPE_MISMATCH;
         }   // end if
         break;
 #if defined(EVP_PKEY_ED25519)
     case DKIM_KEY_TYPE_ED25519:
-        if (EVP_PKEY_ED25519 != EVP_PKEY_type(self->pkey->type)) {
+        if (EVP_PKEY_ED25519 != EVP_PKEY_base_id(self->pkey) {
             DkimLogPermFail
                 ("key-k-tag and key-p-tag doesn't match: domain=%s, keyalg=0x%x, keytype=0x%x",
-                 domain, self->keytype, EVP_PKEY_type(self->pkey->type));
+                 domain, self->keytype, EVP_PKEY_base_id(self->pkey));
             DkimPublicKey_free(self);
             return DSTAT_PERMFAIL_PUBLICKEY_TYPE_MISMATCH;
         }   // end if
@@ -850,7 +851,7 @@ DkimPublicKey_lookup(const DkimVerificationPolicy *policy, const DkimSignature *
     DkimStatus lookup_dstat = DkimPublicKey_lookupImpl(policy, signature, resolver, publickey);
     if (DSTAT_OK == lookup_dstat) {
         // check the key length
-        switch (EVP_PKEY_type((*publickey)->pkey->type)) {
+        switch (EVP_PKEY_base_id((*publickey)->pkey)) {
         case EVP_PKEY_RSA:
             if ((int) policy->min_rsa_key_length > EVP_PKEY_bits((*publickey)->pkey)) {
                 DkimLogPermFail


### PR DESCRIPTION
issue: #9 

This patch adds OpenSSL 1.1 support to libsauth while maintaining compatibility back to OpenSSL 0.9.8.

* `EVP_PKEY` is now opaque. Use `EVP_PKEY_id` and `EVP_PKEY_base_id` to access `pkey->type` and `EVP_PKEY_type(pkey->type)`, resp.  These functions are available since OpenSSL 1.0.0.
* `EVP_MD_CTX` is now opaque. Use `EVP_MD_CTX_new` and `EVP_MD_CTX_free` to  allocate/deallocate its instances. These functions appear at OpenSSL 1.1.0.

I have tested the patched build works on Debian 9 with OpenSSL 1.1.0 and checked that the code compiles with OpenSSL 1.0.1 (Debian 8) and 0.9.8 (Debian 6).