### PR TITLE
Fallback to the default buffer size if sysconf() fails.

### DIFF
--- a/common/daemon_stuff.c
+++ b/common/daemon_stuff.c
@@ -38,7 +38,7 @@
 
 /// テンポラリバッファのサイズ
 #define PIDNUMBUF 128
-
+#define SYSCONF_FALLBACK_PW_BUF_SIZE 1024
 #define PATH_DEVNULL "/dev/null"
 
 struct PidFile {
@@ -216,8 +216,7 @@ setuidgid_r(const char *username, const char **errstr, bool effective)
 
     long buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (0 > buflen) {
-        SETDEREF(errstr, "sysconf failed");
-        return -1;
+        buflen = SYSCONF_FALLBACK_PW_BUF_SIZE;
     }   // end if
     char *buf = (char *) malloc(buflen);
     if (NULL == buf) {


### PR DESCRIPTION
sysconf(_SC_GETPW_R_SIZE_MAX) returns -1 on FreeBSD. So use the default buffer size if it fails.
This change is obtained from enma-1.2.0.

BTW, there is the following comment in src/lib/libc/gen/sysconf.c on FreeBSD.
        /*
         * SUSv4tc1 says the following about _SC_GETGR_R_SIZE_MAX and
         * _SC_GETPW_R_SIZE_MAX:
         * Note that sysconf(_SC_GETGR_R_SIZE_MAX) may return -1 if
         * there is no hard limit on the size of the buffer needed to
         * store all the groups returned.
         */
